### PR TITLE
Add label for staggered pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ Special handling is needed for pods created by a Job controller. By default, Job
 
 Yes. It can even span multiple namespaces.
 
+* **How do I know if a pod is being staggered?
+
+If a pod is being staggered awaiting pacing, it will have label `v1.straggler.technicianted/staggered=1` set. You can list these pods using something like:
+```bash
+$ kubectl get pods -l v1.straggler.technicianted/staggered=1
+```
+
 * **How are pods prevented from starting up (staggered)?**
 
 Straggler works by monitoring pods via an admission controller. With each new pods, it is evaluated against defined policies. Once it is associated with one, its pacer is consulted to see if it should be allowed to start. If it is not, a special pod specs are replaced with stub specs with same resources. Further, an init container is appended that will block the startup of the pod. When the reconciler is ready, the pod is evicted and restarted with its original specs.

--- a/pkg/controller/admission.go
+++ b/pkg/controller/admission.go
@@ -23,6 +23,7 @@ import (
 var (
 	DefaultEnableLabel         = "v1.straggler.technicianted/enable"
 	DefaultStaggerGroupIDLabel = "v1.straggler.technicianted/group"
+	DefaultStaggeredPodLabel   = "v1.straggler.technicianted/staggered"
 	DefaultJobPodLabel         = "v1.straggler.technicianted/jobPod"
 	DefaultFlightWait          = 500 * time.Millisecond
 )
@@ -175,6 +176,8 @@ func (a *Admission) handlePodAdmission(ctx context.Context, pod *corev1.Pod, log
 	}
 
 	logger.Info("pacer will not allow pod")
+	pod.Labels[DefaultStaggeredPodLabel] = "1"
+
 	return a.blockPod(pod, logger)
 }
 

--- a/pkg/controller/admission_test.go
+++ b/pkg/controller/admission_test.go
@@ -69,7 +69,10 @@ func TestAdmissionPodAdmissionBlocking(t *testing.T) {
 	err := admission.Default(context.Background(), &pod)
 	require.NoError(t, err)
 	// check group label
+	require.Contains(t, pod.Labels, DefaultStaggerGroupIDLabel)
 	require.Equal(t, "testid", pod.Labels[DefaultStaggerGroupIDLabel])
+	require.Contains(t, pod.Labels, DefaultStaggeredPodLabel)
+	require.Equal(t, "1", pod.Labels[DefaultStaggeredPodLabel])
 
 	// allow pod. we expect the group label but not blocking
 	pod = corev1.Pod{
@@ -86,7 +89,8 @@ func TestAdmissionPodAdmissionBlocking(t *testing.T) {
 	}, nil)
 	err = admission.Default(context.Background(), &pod)
 	require.NoError(t, err)
-	// check group label
+	// check group label.
+	require.Contains(t, pod.Labels, DefaultStaggerGroupIDLabel)
 	require.Equal(t, "testid", pod.Labels[DefaultStaggerGroupIDLabel])
 
 	// test classifier returning nil group


### PR DESCRIPTION
We need a label to identify pods being staggered. This PR adds `v1.straggler.technicianted/staggered` as a default label set to `1`.