### PR TITLE
Compact flight tracker functionality to bring more consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,4 @@ One of the important design objectives is to be controller agnostic, and be able
 
 * **What about gang scheduling?**
 
-Gang scheduling blocks the scheduling of a group of pods until all requested resources are ready. Straggler handles this by using an init container to block the startup of the pod such that gang schedulers are not affected.
+Gang scheduling blocks the scheduling of a group of pods until all requested resources are ready. Straggler handles this by using an init container to block the startup of the pod such that gang schedulers are not affected. However some orchestrators like Volcano do not have a good way to tolerate pod evictions, which is what straggler uses to unblock the pods.

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/controller-runtime v0.19.0
 	sigs.k8s.io/e2e-framework v0.4.0
-	volcano.sh/apis v1.10.0
 )
 
 require (
@@ -33,6 +32,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -279,5 +279,3 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+s
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
-volcano.sh/apis v1.10.0 h1:Z9eLwibQmhpFmYGLWxjsTWwsYeTEKvvjFcLptmP2qxE=
-volcano.sh/apis v1.10.0/go.mod h1:z8hhFZ2qcUMR1JIjVYmBqL98CVaXNzsQAcqKiytQW9s=

--- a/pkg/controller/admission.go
+++ b/pkg/controller/admission.go
@@ -139,7 +139,7 @@ func (a *Admission) handlePodAdmission(ctx context.Context, pod *corev1.Pod, log
 	logger.V(1).Info("will wait for flight tracker", "wait", DefaultFlightWait)
 	flightCTX, cancel := context.WithTimeout(ctx, DefaultFlightWait)
 	defer cancel()
-	err = a.flightTracker.WaitOne(flightCTX, group.ID, logger)
+	err = a.flightTracker.WaitOne(flightCTX, group.ID, pod.ObjectMeta, logger)
 	if err != nil {
 		logger.Info("failed to wait on flight tracker", "error", err)
 	}
@@ -160,12 +160,6 @@ func (a *Admission) handlePodAdmission(ctx context.Context, pod *corev1.Pod, log
 		return fmt.Errorf("failed to pace pod: %v", err)
 	}
 
-	defer func() {
-		err := a.flightTracker.Track(group.ID, pod.ObjectMeta, logger)
-		if err != nil {
-			logger.Info("failed to track pod flight", "error", err)
-		}
-	}()
 	for _, unblockedPod := range unblocked {
 		if unblockedPod.Name == pod.Name &&
 			unblockedPod.Namespace == pod.Namespace &&

--- a/pkg/controller/admission_test.go
+++ b/pkg/controller/admission_test.go
@@ -197,8 +197,7 @@ func TestAdmissionPodFlight(t *testing.T) {
 	blocker := blockermocks.NewMockPodBlocker(mockCtrl)
 	flightTracker := mocks.NewMockAdmissionFlightTracker(mockCtrl)
 	flightChan := make(chan struct{})
-	flightTracker.EXPECT().Track(gomock.Any(), pod.ObjectMeta, gomock.Any()).Return(nil)
-	flightTracker.EXPECT().WaitOne(gomock.Any(), gomock.Any(), gomock.All()).DoAndReturn(
+	flightTracker.EXPECT().WaitOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.All()).DoAndReturn(
 		func(_ context.Context, _ string, _ logr.Logger) error {
 			<-flightChan
 			return nil

--- a/pkg/controller/flightracker.go
+++ b/pkg/controller/flightracker.go
@@ -116,7 +116,6 @@ func (f *flightTracker) WaitOne(ctx context.Context, key string, object metav1.O
 		return nil
 	}
 
-	fmt.Printf("list: %v\n", flights)
 	logger.V(1).Info("awaiting a flight to land", "inflight", len)
 	select {
 	case <-waitChan:
@@ -236,7 +235,6 @@ func (f *flightTracker) startEvicter(logger logr.Logger) {
 					if time.Since(flight.timestamp) > f.maxFlightDuration {
 						logger.Info("force landing flight", "flight", flight.object, "key", key)
 						go func() {
-							fmt.Printf("list: %v\n", flightList)
 							logger.Info("writing flight chan", "flight", flight.object, "key", key)
 							flightList.landedChan <- nil
 							logger.Info("done writing flight chan", "flight", flight.object, "key", key)

--- a/pkg/controller/flightracker.go
+++ b/pkg/controller/flightracker.go
@@ -48,7 +48,7 @@ type flightTracker struct {
 // unavoidable but we try to minimize them.
 // Implementation uses client to fetch and check committed objects. For safety,
 // pods that exceed maxFlightDuration and automatically assumed committed.
-// objectKeyLabel should match the same label that the admision controller
+// objectKeyLabel should match the same label that the admission controller
 // uses to set the grouping key.
 //
 // TODO: This is overly complex.
@@ -70,22 +70,15 @@ func NewFlightTracker(
 	return tracker
 }
 
-// Track a pod until it get recinciled in the API server. This includes pods that
-// don't yet have a Name but only GenerateName.
-func (f *flightTracker) Track(key string, object metav1.ObjectMeta, logger logr.Logger) error {
-	f.Lock()
-	defer f.Unlock()
+// Waits for one flight to land with key or ctx timeout.
+func (f *flightTracker) WaitOne(ctx context.Context, key string, object metav1.ObjectMeta, logger logr.Logger) error {
+	logger = logger.WithValues("key", key)
 
-	name := object.Name
-	if len(name) == 0 {
-		name = object.GenerateName
-	}
-	if len(name) == 0 {
-		return fmt.Errorf("unable to get a unique name for object")
-	}
+	f.Lock()
 
 	flights, ok := f.flightsByKey[key]
 	if !ok {
+		logger.V(1).Info("creating new entry")
 		flights = &flightList{
 			flights:                  list.New(),
 			landedChan:               make(chan interface{}),
@@ -94,6 +87,14 @@ func (f *flightTracker) Track(key string, object metav1.ObjectMeta, logger logr.
 		f.flightsByKey[key] = flights
 	}
 
+	name := object.Name
+	if len(name) == 0 {
+		name = object.GenerateName
+	}
+	if len(name) == 0 {
+		f.Unlock()
+		return fmt.Errorf("unable to get a unique name for object")
+	}
 	flightName := apitypes.NamespacedName{
 		Name:      name,
 		Namespace: object.Namespace,
@@ -103,25 +104,20 @@ func (f *flightTracker) Track(key string, object metav1.ObjectMeta, logger logr.
 		timestamp: time.Now(),
 	})
 
-	logger.Info("tracking new flight", "flight", flightName, "key", key)
+	logger.V(1).Info("tracking new flight", "flight", flightName)
 
-	return nil
-}
+	waitChan := flights.landedChan
 
-// Waits for one flight to land with key or ctx timeout.
-func (f *flightTracker) WaitOne(ctx context.Context, key string, logger logr.Logger) error {
-	f.Lock()
-
-	flights, ok := f.flightsByKey[key]
-	if !ok {
-		logger.V(1).Info("flight key entry does not exist", "key", key)
-		f.Unlock()
+	len := flights.flights.Len()
+	f.Unlock()
+	if len == 1 {
+		// no previous flight, return immediately
+		logger.V(1).Info("no previous flight, returning immediately")
 		return nil
 	}
-	waitChan := flights.landedChan
-	f.Unlock()
 
-	logger.V(10).Info("awaiting a flight to land", "key", key)
+	fmt.Printf("list: %v\n", flights)
+	logger.V(1).Info("awaiting a flight to land", "inflight", len)
 	select {
 	case <-waitChan:
 		return nil
@@ -205,7 +201,7 @@ func (f *flightTracker) Reconcile(ctx context.Context, request reconcile.Request
 			flightList.landedChan <- nil
 		}()
 	} else {
-		logger.V(10).Info("no matched flight found")
+		logger.V(1).Info("no matched flight found")
 	}
 
 	return reconcile.Result{}, nil
@@ -238,9 +234,12 @@ func (f *flightTracker) startEvicter(logger logr.Logger) {
 				for el != nil {
 					flight := el.Value.(*flight)
 					if time.Since(flight.timestamp) > f.maxFlightDuration {
-						logger.Info("force landing flight", "flight", flight.object)
+						logger.Info("force landing flight", "flight", flight.object, "key", key)
 						go func() {
+							fmt.Printf("list: %v\n", flightList)
+							logger.Info("writing flight chan", "flight", flight.object, "key", key)
 							flightList.landedChan <- nil
+							logger.Info("done writing flight chan", "flight", flight.object, "key", key)
 						}()
 						next := el.Prev()
 						flightList.flights.Remove(el)

--- a/pkg/controller/mocks/blockers.go
+++ b/pkg/controller/mocks/blockers.go
@@ -329,30 +329,16 @@ func (m *MockAdmissionFlightTracker) EXPECT() *MockAdmissionFlightTrackerMockRec
 	return m.recorder
 }
 
-// Track mocks base method.
-func (m *MockAdmissionFlightTracker) Track(key string, object v10.ObjectMeta, logger logr.Logger) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Track", key, object, logger)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Track indicates an expected call of Track.
-func (mr *MockAdmissionFlightTrackerMockRecorder) Track(key, object, logger any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Track", reflect.TypeOf((*MockAdmissionFlightTracker)(nil).Track), key, object, logger)
-}
-
 // WaitOne mocks base method.
-func (m *MockAdmissionFlightTracker) WaitOne(ctx context.Context, key string, logger logr.Logger) error {
+func (m *MockAdmissionFlightTracker) WaitOne(ctx context.Context, key string, object v10.ObjectMeta, logger logr.Logger) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitOne", ctx, key, logger)
+	ret := m.ctrl.Call(m, "WaitOne", ctx, key, object, logger)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WaitOne indicates an expected call of WaitOne.
-func (mr *MockAdmissionFlightTrackerMockRecorder) WaitOne(ctx, key, logger any) *gomock.Call {
+func (mr *MockAdmissionFlightTrackerMockRecorder) WaitOne(ctx, key, object, logger any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitOne", reflect.TypeOf((*MockAdmissionFlightTracker)(nil).WaitOne), ctx, key, logger)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitOne", reflect.TypeOf((*MockAdmissionFlightTracker)(nil).WaitOne), ctx, key, object, logger)
 }

--- a/pkg/controller/noopflighttracker.go
+++ b/pkg/controller/noopflighttracker.go
@@ -15,10 +15,6 @@ var _ types.AdmissionFlightTracker = &noopFlightTracker{}
 
 type noopFlightTracker struct{}
 
-func (n *noopFlightTracker) Track(key string, object metav1.ObjectMeta, logger logr.Logger) error {
-	return nil
-}
-
-func (n *noopFlightTracker) WaitOne(ctx context.Context, key string, logger logr.Logger) error {
+func (n *noopFlightTracker) WaitOne(ctx context.Context, key string, object metav1.ObjectMeta, logger logr.Logger) error {
 	return nil
 }

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -61,6 +61,5 @@ type PodClassifierConfigurator interface {
 // race admitted pods and committed pods.
 // It is assumed that it is best effort.
 type AdmissionFlightTracker interface {
-	Track(key string, object metav1.ObjectMeta, logger logr.Logger) error
-	WaitOne(ctx context.Context, key string, logger logr.Logger) error
+	WaitOne(ctx context.Context, key string, object metav1.ObjectMeta, logger logr.Logger) error
 }

--- a/test/controller_test.go
+++ b/test/controller_test.go
@@ -321,6 +321,7 @@ var _ = Describe("Volcano Happy Case Scenario", func() {
 				500*time.Millisecond, // interval
 				"2 pods should be ready, 1 starting, 7 blocked", // description
 			)
+			fmt.Println("Step 3: 2 ready, 2 starting, 6 blocked")
 
 			// Make the starting pods ready
 			makePodsReady(ctx, starting)
@@ -357,6 +358,7 @@ var _ = Describe("Volcano Happy Case Scenario", func() {
 				500*time.Millisecond, // interval
 				"4 pods should be ready, 6 starting, 0 blocked", // description
 			)
+			fmt.Println("Step 5: 10 ready, 0 starting, 0 blocked")
 
 			// Make the starting pods ready
 			makePodsReady(ctx, starting)


### PR DESCRIPTION
During e2e tests where every component is running on localhost, the time between the admission controller makes a call to the flight tracker to await, and the time it makes a call to track current pod is enough for race condition and may allow more than needed.

This PR combines the two Await and Track operations into a single one to reduce such chances. This brings consistent results for the e2e tests.

Also remove the tentative Volcano e2e test since Volcano cannot gracefully handle pod eviction.