### PR TITLE
Add support for maximum blocking duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ staggeringPolicies:
   labelSelector:
     staggerimages: "1"
   # maximum time to keep a pod staggered after which 
-  # it will be automaticallys started.
+  # it will be automatically started.
   # defaults to inifnite.
   maxBlockedDuration: 10m
   # stagger pods in groups by evaluating this jsonpath.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ staggeringPolicies:
   # only pods carrying this label will be considered.
   labelSelector:
     staggerimages: "1"
+  # maximum time to keep a pod staggered after which 
+  # it will be automaticallys started.
+  # defaults to inifnite.
+  maxBlockedDuration: 10m
   # stagger pods in groups by evaluating this jsonpath.
   # in other words, pods with similar images are put in
   # the same group.

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -4,6 +4,7 @@ staggeringPolicies:
   # only pods carrying this label will be considered.
   labelSelector:
     staggerimages: "1"
+  maxBlockedDuration: 10m
   # stagger pods in groups by evaluating this jsonpath.
   # in other words, pods with similar images are put in
   # the same group.

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -81,7 +81,7 @@ func NewCMDWithManager(mgr manager.Manager, options Options, logger logr.Logger)
 func NewCMD(options Options, logger logr.Logger) (*CMD, error) {
 	kubernetesConfig, err := CreateKubernetesConfig(options.KubernetesOptions)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernets config: %v", err)
+		return nil, fmt.Errorf("failed to create kubernetes config: %v", err)
 	}
 	options.Config = kubernetesConfig
 

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -30,6 +31,7 @@ type StaggeringPolicy struct {
 	LabelSelector       map[string]string
 	BypassLabelSelector map[string]string
 	GroupingExpression  string
+	MaxBlockedDuration  metav1.Duration
 	Pacer               Pacer
 }
 

--- a/pkg/cmd/factories.go
+++ b/pkg/cmd/factories.go
@@ -102,6 +102,7 @@ func NewGroupClassifier(policies []StaggeringPolicy, logger logr.Logger) (contro
 			LabelSelector:       policy.LabelSelector,
 			BypassLabelSelector: policy.BypassLabelSelector,
 			GroupingExpression:  policy.GroupingExpression,
+			MaxBlockedDuration:  policy.MaxBlockedDuration.Duration,
 			PacerFactory:        pacerFactory,
 		}, logger)
 		if err != nil {

--- a/pkg/config/types/types.go
+++ b/pkg/config/types/types.go
@@ -2,7 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 package types
 
-import pacertypes "straggler/pkg/pacer/types"
+import (
+	"time"
+
+	pacertypes "straggler/pkg/pacer/types"
+)
 
 type StaggerGroup struct {
 	// group name. must be unique.
@@ -13,6 +17,8 @@ type StaggerGroup struct {
 	BypassLabelSelector map[string]string
 	// jsonpath aggregation grouping expression.
 	GroupingExpression string
+	// Maximum time to keep a pod in blocked state. Default none.
+	MaxBlockedDuration time.Duration
 
 	PacerFactory pacertypes.PacerFactory
 }

--- a/pkg/controller/admission_test.go
+++ b/pkg/controller/admission_test.go
@@ -19,7 +19,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestAdmissionEnableLabel(t *testing.T) {
@@ -44,7 +43,7 @@ func TestAdmissionPodAdmissionBlocking(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	pod := corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				DefaultEnableLabel: "1",
 			},
@@ -77,7 +76,7 @@ func TestAdmissionPodAdmissionBlocking(t *testing.T) {
 
 	// allow pod. we expect the group label but not blocking
 	pod = corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				DefaultEnableLabel: "1",
 			},
@@ -96,7 +95,7 @@ func TestAdmissionPodAdmissionBlocking(t *testing.T) {
 
 	// test classifier returning nil group
 	pod = corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				DefaultEnableLabel: "1",
 			},
@@ -114,7 +113,7 @@ func TestAdmissionPodErrorBypass(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	pod := corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				DefaultEnableLabel: "1",
 			},
@@ -150,7 +149,7 @@ func TestAdmissionJobSimple(t *testing.T) {
 	job := batchv1.Job{
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						DefaultEnableLabel: "1",
 					},
@@ -178,7 +177,7 @@ func TestAdmissionPodFlight(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	pod := corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				DefaultEnableLabel: "1",
 			},

--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -76,7 +76,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		pod.Labels = make(map[string]string)
 	}
 	if _, ok := pod.Labels[DefaultStaggeredPodLabel]; !ok {
-		logger.V(1).Info("pod does is not staggered")
+		logger.V(1).Info("pod is not staggered")
 		return reconcile.Result{}, nil
 	}
 	groupID, ok := pod.Labels[r.staggerGroupIDLabel]

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -4,6 +4,7 @@ package types
 
 import (
 	"context"
+	"time"
 
 	configtypes "straggler/pkg/config/types"
 	pacertypes "straggler/pkg/pacer/types"
@@ -28,6 +29,12 @@ type ObjectRecorderFactory interface {
 	RecorderForRootController(ctx context.Context, object runtime.Object, logger logr.Logger) (ObjectRecorder, error)
 }
 
+// Policies applied to a staggering group, which may be compoised
+// of multiple staggering policies configs.
+type StaggeringGroupPolicies struct {
+	MaxBlockedDuration time.Duration
+}
+
 // Pod classification result.
 type PodClassification struct {
 	// Unique ID to identify this particular pacer instance. It
@@ -35,6 +42,10 @@ type PodClassification struct {
 	ID string
 	// Pacer used for staggering this pod.
 	Pacer pacertypes.Pacer
+	// GroupPolicies are a set of policies to be applied to this
+	// staggering group based on the underlying one or more
+	// matched policies.
+	GroupPolicies StaggeringGroupPolicies
 }
 
 // Classify a pod to a staggering pacer.


### PR DESCRIPTION
* Reduce reconciler to only consider blocked pods to avoid redundant work.
* To avoid missed events, also add reconciler requeuing of blocked pods to be re-evaluated periodically.
* Now that we have requeuing, add support for `MaxBlockedDuration` to forceibly unblock a pod of a certain threshold is passed.